### PR TITLE
Updated "has-session" check

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -4,7 +4,7 @@
 unset RBENV_VERSION
 unset RBENV_DIR
 
-<%= tmux %> start-server\; has-session = <%= name %> 2>/dev/null
+<%= tmux %> start-server\; ls | grep "^<%= name %>:" 2>/dev/null
 
 if [ "$?" -eq 1 ]; then
   cd <%= root || "." %>


### PR DESCRIPTION
has-sesson check which does not match prefixes and works with tmux 1.8.

Related to https://github.com/tmuxinator/tmuxinator/commit/452d3bd6135631b58af9f75599b8899ebaec63d2